### PR TITLE
exit status variable now read as $status, not $?

### DIFF
--- a/py/sremote/res/setup_bootstrap.sh
+++ b/py/sremote/res/setup_bootstrap.sh
@@ -28,7 +28,7 @@ cd $install_dir
 
 
 which virtualenv
-if ($? == 1) then
+if ($status == 1) then
 	echo "Virutalenv is not available, installing"
 	mkdir pythonuserbase
 	setenv PYTHONUSERBASE "./pythonuserbase"


### PR DESCRIPTION
(this was breaking the code in some versions of csh)

Solves issue #2 
