### PR TITLE
Version control between local and remote

### DIFF
--- a/bin/client/ssh.py
+++ b/bin/client/ssh.py
@@ -55,6 +55,22 @@ def exception_trigger(value):
         print "Exception to be raised, ValueError: "+str(e)  
         
 
+def setting_remote_var():
+    client.register_remote_env_variable("myVar", "myValue")
+    
+    return_value, out = client.do_remote_call("os", "getenv", 
+                                              args=["HOME"]
+                                              )
+    
+    print "HOME", return_value
+    return_value, out = client.do_remote_call("os", "getenv", 
+                                              args=["myVar"]
+                                              )
+    print out
+    print "They should be the same value",  return_value, "myValue"
+    
+        
+
 
 #
 # client.do_bootstrap_install()
@@ -69,7 +85,9 @@ connector.auth(argv[2])
 client = remote.RemoteClient(connector)
 
 
+setting_remote_var()
 
+exit()
 
 print valid_queue_name("juanito")
 print valid_queue_name_dict("juanito!")

--- a/bin/client/ssh.py
+++ b/bin/client/ssh.py
@@ -8,7 +8,7 @@ python newt.py full_hostname username password
 
 import sremote.api as remote
 import sremote.connector.ssh as ssh
-from sremote.tools import ExceptionRemoteExecError
+from sremote.tools import ExceptionRemoteExecError, ExceptionRemoteModulesError
 import time
 from sys import argv
 
@@ -38,7 +38,7 @@ def exception_trigger(value):
         return_value, out = client.do_remote_call("random_module",
                                                   "valid_queue_name", 
                                                   args={"name":value})
-    except ExceptionRemoteExecError as e:
+    except ExceptionRemoteModulesError as e:
         print "Exception to be raised, module does not exist: "+str(e)
         
     try:

--- a/py/setup.py
+++ b/py/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 setup(
     name="sremote",
     packages=find_packages(),
-    version="0.1",
+    version="0.11",
     # install_requires=[s.strip() for s in open("requirements.txt")],
     extras_require={},
     package_data={"sremote": ["res/*.*"]},

--- a/py/setup.py
+++ b/py/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 setup(
     name="sremote",
     packages=find_packages(),
-    version="0.11",
+    version="0.12",
     # install_requires=[s.strip() for s in open("requirements.txt")],
     extras_require={},
     package_data={"sremote": ["res/*.*"]},

--- a/py/setup.py
+++ b/py/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 setup(
     name="sremote",
     packages=find_packages(),
-    version="0.12",
+    version="0.13",
     # install_requires=[s.strip() for s in open("requirements.txt")],
     extras_require={},
     package_data={"sremote": ["res/*.*"]},

--- a/py/sremote/api.py
+++ b/py/sremote/api.py
@@ -121,7 +121,8 @@ class RemoteClient(object):
         output, err, rc = self._comms_client.execute_command("/bin/csh", 
                             [install_dir+"/setup_bootstrap.sh"])
         print "Install result:", rc, output, err
-        self.do_install_git_module("https://github.com/gonzalorodrigo/qdo_interpreter.git")
+        self.do_install_git_module("https://github.com/gonzalorodrigo/qdo_interpreter.git",
+                                   "remote")
         return True
     
     def do_install_git_module(self, git_url, branch=None):
@@ -275,7 +276,7 @@ class ClientChannel(object):
         local_route_response = self.get_local_temp_file_route(False)
         if not self.retrieve_file(method_responde_reference,
                                   local_route_response):
-            raise remote.ExceptionRemoteExecError("retrieve_call_response: " +
+            raise ExceptionRemoteNotSetup("retrieve_call_response: " +
                                                   "Result of method could not" +
                                                   " be retrieved. Pointer: " +
                                                   str(method_responde_reference)

--- a/py/sremote/api.py
+++ b/py/sremote/api.py
@@ -115,7 +115,7 @@ class RemoteClient(object):
                             [install_dir+"/setup_bootstrap.sh"])
         print "Install result:", rc, output, err
         self.do_install_git_module("https://github.com/gonzalorodrigo/qdo_interpreter.git",
-                                   "remote")
+                                   "integration")
         return True
     
     def do_install_git_module(self, git_url, branch=None):

--- a/py/sremote/api.py
+++ b/py/sremote/api.py
@@ -14,13 +14,6 @@ import types
 import uuid
 from __builtin__ import str
 
-class ExceptionRemoteNotSetup(Exception):
-    pass
-
-
-
-
-
 class RemoteClient(object):
     """Base class for the client side of the remoting functions including:
     - Deployment of the the sremote environment in the remote host.
@@ -80,7 +73,7 @@ class RemoteClient(object):
                         raise remote.ExceptionRemoteExecError(response[
                                                                 "message"])
             
-            raise ExceptionRemoteNotSetup(
+            raise remote.ExceptionRemoteNotSetup(
                 "Error executing " +module_name+"."+ method_name + "\n  Output:"
                 +str(std_out))
 
@@ -276,7 +269,7 @@ class ClientChannel(object):
         local_route_response = self.get_local_temp_file_route(False)
         if not self.retrieve_file(method_responde_reference,
                                   local_route_response):
-            raise ExceptionRemoteNotSetup("retrieve_call_response: " +
+            raise remote.ExceptionRemoteNotSetup("retrieve_call_response: " +
                                                   "Result of method could not" +
                                                   " be retrieved. Pointer: " +
                                                   str(method_responde_reference)

--- a/py/sremote/connector/newt.py
+++ b/py/sremote/connector/newt.py
@@ -87,7 +87,7 @@ class ClientNEWTConnector(remote_api.ClientChannel):
         cmdurl = ("https://newt.nersc.gov/newt/file/" + self._hostname
                   + dest_route)
 
-        qdo_getkey = self._token
+        qdo_authkey = self._token
         text_file = open(origin_route, "r")
         results = requests.put(cmdurl, text_file,
                                cookies={'newt_sessionid': qdo_authkey})

--- a/py/sremote/connector/newt.py
+++ b/py/sremote/connector/newt.py
@@ -123,11 +123,11 @@ class ClientNEWTConnector(remote_api.ClientChannel):
         )
         if keep_env:
             data['loginenv'] = 'true'
-        print data
+        #print data
         
         results = requests.post(cmdurl, data,
                                 cookies={'newt_sessionid': qdo_authkey})
-        print results
+        #print results
         output = results.json()["output"]
         error = results.json()["error"]
         del results

--- a/py/sremote/connector/newt.py
+++ b/py/sremote/connector/newt.py
@@ -14,7 +14,7 @@ class ClientNEWTConnector(remote_api.ClientChannel):
         self._token = None
     
     
-    def auth(self, username, password=None, token=None):
+    def auth(self, username, password=None, token=None, home_dir=None):
         """Auth method. It performs auth operation against the newt server and
         stores the token for futher use. It also detects the users login dir
         and stores it.
@@ -46,7 +46,10 @@ class ClientNEWTConnector(remote_api.ClientChannel):
                     self._token = newt_sessionid
                     del res_obj
                     del results
-                    self._home_dir = self.get_pwd()
+                    if home_dir:
+                        self._home_dir = home_dir 
+                    else:
+                        self._home_dir = self.get_pwd()
                     return True
                 del res_obj
                 del results
@@ -57,7 +60,10 @@ class ClientNEWTConnector(remote_api.ClientChannel):
                 return False
         else:
             self._token = token
-            self._home_dir = self.get_pwd()
+            if home_dir:
+                self._home_dir = home_dir 
+            else:
+                self._home_dir = self.get_pwd()
             print self._home_dir
             if self._home_dir!=None:
                 return True
@@ -81,7 +87,7 @@ class ClientNEWTConnector(remote_api.ClientChannel):
         cmdurl = ("https://newt.nersc.gov/newt/file/" + self._hostname
                   + dest_route)
 
-        qdo_authkey = self._token
+        qdo_getkey = self._token
         text_file = open(origin_route, "r")
         results = requests.put(cmdurl, text_file,
                                cookies={'newt_sessionid': qdo_authkey})

--- a/py/sremote/connector/ssh.py
+++ b/py/sremote/connector/ssh.py
@@ -12,7 +12,7 @@ class ClientSSHConnector(remote_api.ClientChannel):
         self._interpreter_route = interpreter_route
         self._hostname = hostname;
 
-    def auth(self, username, password=None, token=None):
+    def auth(self, username, password=None, token=None, home_dir=None):
         """Auth method. It stores the username. Authenticaion does not
         occur until an actual operation is executed. It no ssh key is
         configured in the client, future operations will ask for password."""

--- a/py/sremote/connector/ssh.py
+++ b/py/sremote/connector/ssh.py
@@ -28,7 +28,7 @@ class ClientSSHConnector(remote_api.ClientChannel):
     def push_file(self, origin_route, dest_route):
         command_list =  ["scp", origin_route, self._username + "@" +
                          self._hostname + ":" + dest_route]
-        print command_list
+        #print command_list
         p = subprocess.Popen(command_list, stdout=subprocess.PIPE)
         output, err = p.communicate()
         rc = p.returncode
@@ -39,7 +39,7 @@ class ClientSSHConnector(remote_api.ClientChannel):
     def retrieve_file(self, origin_route, dest_route):
         command_list =  ["scp", self._username + "@" +
                  self._hostname + ":" + origin_route,  dest_route]
-        print command_list
+        #print command_list
         p = subprocess.Popen(command_list, stdout=subprocess.PIPE)
         output, err = p.communicate()
         rc = p.returncode

--- a/py/sremote/tools.py
+++ b/py/sremote/tools.py
@@ -132,9 +132,9 @@ def decode_call_response(call_response_serialized):
         raise ExceptionRemoteNotSetup("SREMOTE Version info not present in"+
                                       " response")
     if response_obj[RESPONSE_VERSION] != version:
-        raise ExceptionRemoteNotSetup("SERMOTE version miss-match: local("
+        raise ExceptionRemoteNotSetup("SERMOTE version miss-match: remote("
                                       + str(response_obj[RESPONSE_VERSION])
-                                      +") != remote("+version
+                                      +") != local("+version
                                       +")")
     return response_obj[RESPONSE_STATUS], response_obj[RESPONSE_CONTENT]
    

--- a/py/sremote/tools.py
+++ b/py/sremote/tools.py
@@ -112,8 +112,6 @@ def encode_call_request(module_name, command_name, args = [],
                         required_extra_modules = []):
     """Creates a call_request_object and serializes it."""
     all_modules = required_extra_modules
-    if not module_name in all_modules:
-        all_modules=required_extra_modules + [module_name]
     command_obj = {COMMAND_TYPE: command_name}
     command_obj[COMMAND_ARGS] = args
     command_obj[COMMAND_MODULE] = module_name


### PR DESCRIPTION
Local and remote sremote must be in the same version. This pull requests makes srmote check and
compare versions and raise an exception if the versions don't match.

Extra features:
- Setting remote environment variables
- home_dir can be set in NEWT connector, so htere is no need to retrieve it.
